### PR TITLE
Fixing how build_ext is being imported to allow setup.py to run succe…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from distutils.extension import Extension
 import numpy as np
 
 try:
-    from Cython.Distutils import build_ext
+    from Cython.Distutils.build_ext import build_ext
     src = ['sselogsumexp.pyx', 'src/logsumexp.c']
 except ImportError:
-    from distutils.command import build_ext
+    from distutils.command.build_ext import build_ext
     src = ['sselogsumexp.c', 'src/logsumexp.c']
 
 ext = Extension("sselogsumexp", src,


### PR DESCRIPTION
A StackOverflow question was posted with reference to this project: 

http://stackoverflow.com/questions/32628134/distutils-setup-py-install-module-object-is-not-callable

There seems to be an issue in the setup.py on how the build_ext is attempted to be run. I tested on my end and the issue is when are not using the Distutils packaged inside Cython and your except block is executed instead to use the standard distutils package. 

I ran the setup.py on my machine with the mod to ensure it ran.
